### PR TITLE
subscribe + mfix example

### DIFF
--- a/examples/subscribe.hs
+++ b/examples/subscribe.hs
@@ -4,13 +4,14 @@ import qualified CDP as CDP
 import Data.Default (def)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever)
+import Control.Monad.Fix (mfix)
 
 main :: IO ()
 main = CDP.runClient def $ \handle -> do
     CDP.pageEnable handle
-    sub1 <- CDP.subscribe handle $ \e ->
+    sub1 <- mfix $ \sub -> CDP.subscribe handle $ \e -> do
         putStrLn $ "1: " ++ CDP.pageFrameUrl (CDP.pageFrameNavigatedFrame e)
-    _ <- CDP.subscribe handle $ \e -> do
+        CDP.unsubscribe handle sub
+    _ <- CDP.subscribe handle $ \e ->
         putStrLn $ "2: " ++ CDP.pageFrameUrl (CDP.pageFrameNavigatedFrame e)
-        CDP.unsubscribe handle sub1
     forever $ threadDelay 1000


### PR DESCRIPTION
I was wondering if we should pass `Subscription` as an extra parameter to subscribe, to make it possible to unsubscribe from withing the handler, e.g.:

    CDP.pageEnable handle
    sub1 <- CDP.subscribe handle $ \sub e -> do
        putStrLn $ "1: " ++ CDP.pageFrameUrl (CDP.pageFrameNavigatedFrame e)
        CDP.unsubscribe handle sub

However, most of the time you want to ignore this parameter, so this makes it a bit ugly.  But it turns out you can also do this using `mfix`, so I wanted to add an example of that.