### PR TITLE
Simplify definition for gen

### DIFF
--- a/gen/CDP/Definition.hs
+++ b/gen/CDP/Definition.hs
@@ -20,12 +20,6 @@ import           Data.Monoid((<>))
 import           Data.Text (Text)
 import qualified GHC.Generics
 
-data a :|: b = AltLeft a | AltRight b
-    deriving (Eq, GHC.Generics.Generic, Show)
-
-instance (FromJSON a, FromJSON b) => FromJSON (a :|: b) where
-    parseJSON x = (AltLeft <$> parseJSON x) <|> (AltRight <$> parseJSON x)
-
 data Version = Version { 
     versionMinor :: Text,
     versionMajor :: Text
@@ -38,8 +32,8 @@ instance FromJSON Version where
 
 
 data Items = Items { 
-    itemsType :: (Maybe (Text:|:[(Maybe Value)])),
-    itemsRef :: (Maybe (Text:|:[(Maybe Value)]))
+    itemsType :: Maybe Text,
+    itemsRef :: Maybe Text
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -49,14 +43,14 @@ instance FromJSON Items where
 
 
 data ReturnsElt = ReturnsElt { 
-    returnsEltItems :: (Maybe (Items:|:[(Maybe Value)])),
-    returnsEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    returnsEltItems :: Maybe Items,
+    returnsEltExperimental :: Maybe Bool,
     returnsEltName :: Text,
-    returnsEltType :: (Maybe (Text:|:[(Maybe Value)])),
-    returnsEltOptional :: (Maybe (Bool:|:[(Maybe Value)])),
-    returnsEltRef :: (Maybe (Text:|:[(Maybe Value)])),
-    returnsEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    returnsEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    returnsEltType :: Maybe Text,
+    returnsEltOptional :: Maybe Bool,
+    returnsEltRef :: Maybe Text,
+    returnsEltDescription :: Maybe Text,
+    returnsEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -66,15 +60,15 @@ instance FromJSON ReturnsElt where
 
 
 data ParametersElt = ParametersElt { 
-    parametersEltItems :: (Maybe (Items:|:[(Maybe Value)])),
-    parametersEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    parametersEltItems :: Maybe Items,
+    parametersEltExperimental :: Maybe Bool,
     parametersEltName :: Text,
-    parametersEltType :: (Maybe (Text:|:[(Maybe Value)])),
+    parametersEltType :: Maybe Text,
     parametersEltEnum :: (Maybe ([Text])),
-    parametersEltOptional :: (Maybe (Bool:|:[(Maybe Value)])),
-    parametersEltRef :: (Maybe (Text:|:[(Maybe Value)])),
-    parametersEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    parametersEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    parametersEltOptional :: Maybe Bool,
+    parametersEltRef :: Maybe Text,
+    parametersEltDescription :: Maybe Text,
+    parametersEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -84,13 +78,13 @@ instance FromJSON ParametersElt where
 
 
 data CommandsElt = CommandsElt { 
-    commandsEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    commandsEltExperimental :: Maybe Bool,
     commandsEltName :: Text,
     commandsEltReturns :: (Maybe ([ReturnsElt])),
     commandsEltParameters :: (Maybe ([ParametersElt])),
-    commandsEltRedirect :: (Maybe (Text:|:[(Maybe Value)])),
-    commandsEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    commandsEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    commandsEltRedirect :: Maybe Text,
+    commandsEltDescription :: Maybe Text,
+    commandsEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -100,14 +94,14 @@ instance FromJSON CommandsElt where
 
 
 data TypesElt = TypesElt { 
-    typesEltItems :: (Maybe (Items:|:[(Maybe Value)])),
-    typesEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    typesEltItems :: Maybe Items,
+    typesEltExperimental :: Maybe Bool,
     typesEltId :: Text,
     typesEltType :: Text,
     typesEltEnum :: (Maybe ([Text])),
     typesEltProperties :: (Maybe ([ParametersElt])),
-    typesEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    typesEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    typesEltDescription :: Maybe Text,
+    typesEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -117,11 +111,11 @@ instance FromJSON TypesElt where
 
 
 data EventsElt = EventsElt { 
-    eventsEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    eventsEltExperimental :: Maybe Bool,
     eventsEltName :: Text,
     eventsEltParameters :: (Maybe ([ParametersElt])),
-    eventsEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    eventsEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    eventsEltDescription :: Maybe Text,
+    eventsEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 
@@ -134,11 +128,11 @@ data DomainsElt = DomainsElt {
     domainsEltCommands :: [CommandsElt],
     domainsEltDomain :: Text,
     domainsEltDependencies :: (Maybe ([Text])),
-    domainsEltExperimental :: (Maybe (Bool:|:[(Maybe Value)])),
+    domainsEltExperimental :: Maybe Bool,
     domainsEltTypes :: (Maybe ([TypesElt])),
     domainsEltEvents :: (Maybe ([EventsElt])),
-    domainsEltDescription :: (Maybe (Text:|:[(Maybe Value)])),
-    domainsEltDeprecated :: (Maybe (Bool:|:[(Maybe Value)]))
+    domainsEltDescription :: Maybe Text,
+    domainsEltDeprecated :: Maybe Bool
   } deriving (Show,Eq,GHC.Generics.Generic)
 
 

--- a/gen/CDP/Gen/Program.hs
+++ b/gen/CDP/Gen/Program.hs
@@ -19,7 +19,6 @@ import qualified Data.Graph as Graph
 import qualified Data.Text as T
 import qualified Data.Aeson as A
 
-import CDP.Definition ((:|:)(AltLeft, AltRight))
 import qualified CDP.Definition as D
 import qualified CDP.Gen.Snippets as Snippets
 
@@ -119,8 +118,8 @@ genType ctx domainName telt = T.unlines . (desc :) . pure $ case D.typesEltEnum 
             ty       ->  T.unwords ["type", tn, "=", lty]                 
   where
     desc     = let td = "Type '" <> (domainName <> "." <> D.typesEltId telt) <> "'." in 
-        formatDescription 0 . ((td <> "\n") <>) . maybe "" fromAltLeft $ D.typesEltDescription telt
-    lty      = leftType ctx domainName (Just . AltLeft $ tytelt) Nothing (D.typesEltItems telt)
+        formatDescription 0 . ((td <> "\n") <>) . fromMaybe "" $ D.typesEltDescription telt
+    lty      = leftType ctx domainName (Just tytelt) Nothing (D.typesEltItems telt)
     tytelt   = D.typesEltType telt
     tpeltsM  = guardEmptyList isValidParam $ D.typesEltProperties telt
     tn       = typeNameHS domainName telt 
@@ -165,7 +164,7 @@ genCommand ctx domainName commandElt = T.unlines $
     pdesc = formatDescription 0 $ "Parameters of the '" <> (commandFnName rtn) <> "' command."
     desc = let td = "Function for the '" <> cn <> "' command." in
         formatDescription 0 . T.intercalate "\n" . catMaybes $ 
-            [ Just $ ((td <> "\n") <>) . maybe "" fromAltLeft $ D.commandsEltDescription commandElt
+            [ Just $ ((td <> "\n") <>) . fromMaybe "" $ D.commandsEltDescription commandElt
             , do
                 guard . not $ null pelts
                 pure ("Returns: '" <> ptn <> "'")
@@ -231,14 +230,14 @@ genParamsType ctx domainName paramsTypeName paramElts = T.unlines . filter ((> 0
     ]
   where
     fields = formatFieldDescription . map toField $ fieldSigDecls
-    toField ((fn,ftn,_),descM) = (T.unwords [fn, "::", ftn], fmap fromAltLeft descM)
+    toField ((fn,ftn,_),descM) = (T.unwords [fn, "::", ftn], descM)
 
     enumDecls    = catMaybes . map (\((_,_,d),_) -> d) $ fieldSigDecls
     fieldSigDecls = map (peltToFieldSigDecl &&& D.parametersEltDescription) paramElts
 
     peltToFieldSigDecl pelt = case D.parametersEltEnum pelt of
         Just enumValues -> (fn, ftn, ) . Just $ genTypeEnum ctx ftn enumValues
-        Nothing         -> (fn, , Nothing) $ genEltType ctx domainName (isTrue . D.parametersEltOptional $ pelt)
+        Nothing         -> (fn, , Nothing) $ genEltType ctx domainName (D.parametersEltOptional pelt == Just True)
                 (D.parametersEltType pelt)
                 (D.parametersEltRef pelt) 
                 (D.parametersEltItems pelt)
@@ -260,14 +259,14 @@ genReturnType ctx domainName returnTypeName returnElts = T.unlines
     desc = formatDescription 0 $ "Return type of the '" <> 
         (commandFnName returnTypeName) <> "' command."
     fields = formatFieldDescription . 
-        map (reltToField &&& fmap fromAltLeft . D.returnsEltDescription) $ returnElts
+        map (reltToField &&& D.returnsEltDescription) $ returnElts
     reltToField relt = T.unwords
         [ fieldNameHS returnTypeName . D.returnsEltName $ relt
         , "::"
         , reltToTypeSig relt
         ]
 
-    reltToTypeSig relt = genEltType ctx domainName (isTrue . D.returnsEltOptional $ relt) 
+    reltToTypeSig relt = genEltType ctx domainName (D.returnsEltOptional relt == Just True)
             (D.returnsEltType relt)
             (D.returnsEltRef relt) 
             (D.returnsEltItems relt)
@@ -286,7 +285,6 @@ formatComponentDescription component = T.unlines
         , domainName delt
         , flip (maybe "") (D.domainsEltDescription delt) $ \descAltM -> 
                 (":\n" <>) . T.unlines . map (space 6 <>) . T.lines $ 
-                fromAltLeft $
                 descAltM
         ]
     delts  = map fst . Map.elems . cDomDeps $ component
@@ -373,19 +371,19 @@ fromJSONOpts :: Int -> T.Text
 fromJSONOpts n    = T.unwords ["A.defaultOptions{A.fieldLabelModifier = uncapitalizeFirst . drop", ((T.pack . show) n), "}"]
 
 ----- Types -----
-genEltType :: Context -> T.Text -> Bool -> (Maybe (T.Text:|:[(Maybe A.Value)])) -> (Maybe (T.Text:|:[(Maybe A.Value)])) -> (Maybe (D.Items:|:[(Maybe A.Value)])) -> T.Text
+genEltType :: Context -> T.Text -> Bool -> Maybe T.Text -> Maybe T.Text -> Maybe D.Items -> T.Text
 genEltType ctx name isOptional t1 t2 items = (if isOptional then "Maybe " else "") <> (leftType ctx name t1 t2 items)
 
-leftType :: Context -> T.Text -> (Maybe (T.Text:|:[(Maybe A.Value)])) -> (Maybe (T.Text:|:[(Maybe A.Value)])) -> (Maybe (D.Items:|:[(Maybe A.Value)])) -> T.Text
-leftType ctx _ (Just (AltLeft ty1)) (Just (AltLeft ty2)) _ = error "impossible"
-leftType ctx domain (Just (AltLeft ty)) _ itemsElt = typeCDPToHS ctx domain ty itemsElt
-leftType ctx domain _ (Just (AltLeft ty)) itemsElt = typeCDPToHS ctx domain ty itemsElt
+leftType :: Context -> T.Text -> Maybe T.Text -> Maybe T.Text -> Maybe D.Items -> T.Text
+leftType ctx _ (Just ty1) (Just ty2) _ = error "impossible"
+leftType ctx domain (Just ty) _ itemsElt = typeCDPToHS ctx domain ty itemsElt
+leftType ctx domain _ (Just ty) itemsElt = typeCDPToHS ctx domain ty itemsElt
 leftType ctx _ _ _ _ = error "no type found"
 
-typeCDPToHS :: Context -> T.Text -> T.Text -> (Maybe (D.Items:|:[(Maybe A.Value)])) -> T.Text
+typeCDPToHS :: Context -> T.Text -> T.Text -> Maybe D.Items -> T.Text
 typeCDPToHS ctx _ "object" _ = "[(String, String)]"
-typeCDPToHS ctx domain "array" (Just (AltLeft items)) = "[" <> (leftType ctx domain (D.itemsType items) (D.itemsRef items) Nothing) <> "]"
-typeCDPToHS ctx _ ty (Just (AltLeft items)) = error . T.unpack $ "non-array type with items: " <> ty
+typeCDPToHS ctx domain "array" (Just items) = "[" <> (leftType ctx domain (D.itemsType items) (D.itemsRef items) Nothing) <> "]"
+typeCDPToHS ctx _ ty (Just items) = error . T.unpack $ "non-array type with items: " <> ty
 typeCDPToHS ctx domain ty Nothing = convertType ctx domain ty
 typeCDPToHS ctx _ _ _ = error "no matching type"
 
@@ -480,7 +478,7 @@ typeDependencies telt = if not (isValidType telt) then [] else
     case D.typesEltEnum telt of 
         Just _  -> []
         Nothing -> case D.typesEltType telt of
-            "array"  -> maybe [] pure . join $ itemDependencies . fromAltLeft <$> D.typesEltItems telt
+            "array"  -> maybe [] pure . join $ itemDependencies <$> D.typesEltItems telt
             "object" -> fromMaybe [] $ catMaybes . map paramDependencies <$> D.typesEltProperties telt
             s -> maybe [] pure $ refTypeToDomain s
 
@@ -500,47 +498,47 @@ paramDependencies pelt = if not (isValidParam pelt) then Nothing else
     case D.parametersEltEnum pelt of 
         Just _  -> Nothing
         Nothing -> case D.parametersEltRef pelt of
-            Just r  -> refTypeToDomain . fromAltLeft $ r
-            Nothing -> case fromAltLeft <$> D.parametersEltType pelt of
+            Just r  -> refTypeToDomain r
+            Nothing -> case D.parametersEltType pelt of
                 Just "object" -> Nothing
-                Just "array"  -> itemDependencies =<< fromAltLeft <$> D.parametersEltItems pelt
+                Just "array"  -> itemDependencies =<< D.parametersEltItems pelt
                 Just s -> refTypeToDomain s
                 _      -> Nothing
 
 returnDependencies :: D.ReturnsElt -> Maybe T.Text
 returnDependencies relt = if not (isValidReturn relt) then Nothing else
     case D.returnsEltRef relt of
-        Just r  -> refTypeToDomain . fromAltLeft $ r
-        Nothing -> case fromAltLeft <$> D.returnsEltType relt of
+        Just r  -> refTypeToDomain r
+        Nothing -> case D.returnsEltType relt of
             Just "object" -> Nothing
-            Just "array"  -> itemDependencies =<< fromAltLeft <$> D.returnsEltItems relt
+            Just "array"  -> itemDependencies =<< D.returnsEltItems relt
             Just s -> refTypeToDomain s
             _     -> Nothing
 
 itemDependencies :: D.Items -> Maybe T.Text
-itemDependencies itelt = refTypeToDomain =<< fromAltLeft <$> D.itemsRef itelt
+itemDependencies itelt = refTypeToDomain =<< D.itemsRef itelt
 
 ----- Validity -----
 validDomains :: [D.DomainsElt] -> [D.DomainsElt]
 validDomains ds = filter isValidDomain $ ds
   
 isValidDomain :: D.DomainsElt -> Bool
-isValidDomain delt = (not . isTrue . D.domainsEltDeprecated $ delt)
+isValidDomain delt = D.domainsEltDeprecated delt /= Just True
 
 isValidType :: D.TypesElt -> Bool
-isValidType telt = (not . isTrue . D.typesEltDeprecated $ telt)
+isValidType telt = D.typesEltDeprecated telt /= Just True
 
 isValidEvent :: D.EventsElt -> Bool
-isValidEvent evelt = (not . isTrue . D.eventsEltDeprecated $ evelt)
+isValidEvent evelt = D.eventsEltDeprecated evelt /= Just True
 
 isValidCommand :: D.CommandsElt -> Bool
-isValidCommand celt = (not . isTrue . D.commandsEltDeprecated $ celt)
+isValidCommand celt = D.commandsEltDeprecated celt /= Just True
 
 isValidParam :: D.ParametersElt -> Bool
-isValidParam pelt = (not . isTrue . D.parametersEltDeprecated $ pelt)
+isValidParam pelt = D.parametersEltDeprecated pelt /= Just True
 
 isValidReturn :: D.ReturnsElt -> Bool
-isValidReturn relt = (not . isTrue . D.returnsEltDeprecated $ relt)
+isValidReturn relt = D.returnsEltDeprecated relt /= Just True
 
 validTypes :: D.DomainsElt -> [D.TypesElt]
 validTypes = filter isValidType . fromMaybe [] . D.domainsEltTypes
@@ -608,15 +606,6 @@ guardEmptyList f v = go =<< (filter f <$> v)
 
 space :: Int -> T.Text
 space n = T.unwords $ replicate n ""
-
-fromMaybeAltLeft :: Maybe (a :|: b) -> a
-fromMaybeAltLeft (Just al) = fromAltLeft al 
-
-fromAltLeft :: a :|: b -> a
-fromAltLeft (AltLeft a) = a
-
-isTrue :: Eq a => Maybe (Bool:|:a) -> Bool
-isTrue = (== (Just $ AltLeft True))
 
 capitalizeFirst :: T.Text -> T.Text
 capitalizeFirst t = maybe t (\(first, rest) -> T.singleton (toUpper first) `T.append` rest) . T.uncons $ t


### PR DESCRIPTION
None of the `:|:(Maybe Value)` stuff is necessary it turns out so this is a nice simplification
