### PR TITLE
By default, make initial connection to page instead of browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ import qualified Data.Text.Lazy.Encoding as TL
 import qualified CDP as CDP
 
 main :: IO ()
-main = do
-    let cfg = def
-    CDP.runClient cfg printPDF
+main = CDP.runClient def printPDF
 
 printPDF :: CDP.Handle -> IO ()
 printPDF handle = do
@@ -62,6 +60,7 @@ whileTrue f act = do
     if f a
         then pure . (a :) =<< whileTrue f act
         else pure [a]
+
 ```
 
 More examples can be found in `examples`.

--- a/cdp.cabal
+++ b/cdp.cabal
@@ -8,11 +8,11 @@ name:           cdp
 version:        0.0.1.1
 synopsis:       A library for the Chrome Devtools Protocol
 description:     A library for the Chrome Devtools Protocol (CDP). It provides access to Chrome, enabling tasks such as printing a page or opening a tab.
-                
+                .
                 Chrome Devtools Protocol: <https://chromedevtools.github.io/devtools-protocol/>
-                
+                .
                 README: <https://github.com/arsalan0c/cdp-hs>
-                
+                .
                 Examples: <https://github.com/arsalan0c/cdp-hs/examples> 
 category:       Package.Category
 homepage:       https://github.com/arsalan0c/cdp-hs#readme

--- a/examples/print-page.hs
+++ b/examples/print-page.hs
@@ -13,9 +13,7 @@ import qualified Data.Text.Lazy.Encoding as TL
 import qualified CDP as CDP
 
 main :: IO ()
-main = do
-    let cfg = def
-    CDP.runClient cfg printPDF
+main = CDP.runClient def printPDF
 
 printPDF :: CDP.Handle -> IO ()
 printPDF handle = do

--- a/examples/sessions.hs
+++ b/examples/sessions.hs
@@ -18,7 +18,7 @@ main = do
 -- Attaches to target, returning the session id
 attachTarget :: CDP.Handle -> IO T.Text
 attachTarget handle = do
-    -- get a target id
+    -- get a target id by sending the Target.getTargets command
     targetInfo <- head . CDP.targetGetTargetsTargetInfos <$> 
         (CDP.sendCommandWait handle $ CDP.PTargetGetTargets Nothing)
     let targetId = CDP.targetTargetInfoTargetId targetInfo

--- a/src/CDP/Endpoints.hs
+++ b/src/CDP/Endpoints.hs
@@ -135,6 +135,10 @@ browserAddress :: (String, Int) -> IO (String, Int, String)
 browserAddress hostPort = fromMaybe (throw . ERRParse $ "invalid URI when connecting to browser") . 
     parseUri . T.unpack . bvWebSocketDebuggerUrl <$> getEndpoint hostPort EPBrowserVersion
 
+pageAddress :: (String, Int) -> IO (String, Int, String)
+pageAddress hostPort = fromMaybe (throw . ERRParse $ "invalid URI when connecting to page") . 
+    parseUri . T.unpack . tiWebSocketDebuggerUrl . head <$> getEndpoint hostPort EPAllTargets
+
 getRequest :: (String, Int) -> [T.Text] -> Maybe T.Text -> Http.Request
 getRequest (host, port) path mbParam = Http.parseRequest_ . T.unpack $ r
   where

--- a/src/CDP/Internal/Utils.hs
+++ b/src/CDP/Internal/Utils.hs
@@ -62,9 +62,9 @@ data Handle = Handle
 
 data Config = Config
     { hostPort           :: (String, Int)
-      -- | WebSocket path to connect to. 
-      --   If Nothing, the initial connection is made to the browser.
-    , path               :: Maybe String 
+      -- | Target of initial connection. 
+      --   If False, the initial connection is made to the page.
+    , connectToBrowser   :: Bool
     , doLogResponses     :: Bool
       -- | Number of microseconds to wait for a command response.
       --   Waits forever if Nothing.
@@ -73,10 +73,10 @@ data Config = Config
 instance Default Config where
     def = Config{..}
       where
-        hostPort       = ("http://127.0.0.1", 9222)
-        path           = def
-        doLogResponses = False
-        commandTimeout = def
+        hostPort         = ("http://127.0.0.1", 9222)
+        connectToBrowser = False
+        doLogResponses   = False
+        commandTimeout   = def
 
 class FromJSON a => Event a where
     eventName :: Proxy a -> String

--- a/src/CDP/Runtime.hs
+++ b/src/CDP/Runtime.hs
@@ -59,8 +59,11 @@ runClient config app = do
     responseBuffer <- newMVar []
 
     (host, port, path) <- do
-        let hp@(host,port) = hostPort config
-        maybe (browserAddress hp) (\path -> pure (host, port, path)) $ path config
+        let hp = hostPort config
+        if connectToBrowser config
+            then browserAddress hp
+            else pageAddress hp
+
     WS.runClient host port path $ \conn -> do
         let listen = forkIO $ do
                 listenThread <- myThreadId

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,8 +6,6 @@ import Test.Hspec
 import Control.Monad
 import Data.Default
 import Control.Concurrent
-import Data.Maybe
-import qualified Data.Text as T
 
 import qualified CDP as CDP
 
@@ -27,14 +25,13 @@ main = hspec $ do
                 ]
 
     targetInfo <- runIO $ CDP.connectToTab def "https://haskell.foundation"
-    let (host,port,path) = fromMaybe (error "invalid uri") . CDP.parseUri . T.unpack . CDP.tiWebSocketDebuggerUrl $ targetInfo
-        cfg      = def{CDP.hostPort = (host,port), CDP.path = Just path}
-        targetId = CDP.tiId targetInfo
-
+    let cfg      = def
     describe "Command responses of the expected type are received" $ do
         it "sends commands: w/o params w/o results" $ do
             CDP.runClient cfg $ \handle -> do
-                CDP.sendCommandForSessionWait handle targetId CDP.PBrowserCrashGpuProcess
+                sessionId <- CDP.targetAttachToTargetSessionId <$> 
+                    (CDP.sendCommandWait handle $ CDP.PTargetAttachToTarget (CDP.tiId targetInfo) (Just True))
+                CDP.sendCommandForSessionWait handle sessionId CDP.PBrowserCrashGpuProcess
         
         it "sends commands: w/o params w/ results" $ do
             void $ CDP.runClient cfg $ \handle -> do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,6 +25,7 @@ main = hspec $ do
                 ]
 
     targetInfo <- runIO $ CDP.connectToTab def "https://haskell.foundation"
+    runIO $ threadDelay 1
     let cfg      = def
     describe "Command responses of the expected type are received" $ do
         it "sends commands: w/o params w/o results" $ do


### PR DESCRIPTION
A page enables greater functionality (eg. printing) compared to the browser target